### PR TITLE
do not set err when file has already been deleted

### DIFF
--- a/utils.c
+++ b/utils.c
@@ -245,7 +245,7 @@ int delete_whiteouts(const char *path)
 			continue;
 
 		ret = lstat(direntp->d_name, &fbuf);
-		if (ret) {
+		if (ret < 0 && !(errno == ENOENT)) {
 			err = true;
 			continue;
 		}


### PR DESCRIPTION
When the whiteout exists and the corresponding file is already deleted do not
set err.

Signed-off-by: Christian Brauner christian.brauner@mailbox.org
