### PR TITLE
skip over already deleted whiteout files

### DIFF
--- a/utils.c
+++ b/utils.c
@@ -254,10 +254,8 @@ int delete_whiteouts(const char *oldpath, const char *newpath)
 		}
 		if (whiteout) {
 			ret = lstat(delete, &s);
-			if (ret) {
-				err = true;
+			if (ret)
 				continue;
-			}
 			if (S_ISDIR(s.st_mode)) {
 				if (recursive_rmdir(delete, false) < 0)
 					err = true;


### PR DESCRIPTION
If we find a whiteout file (e.g. /.wh.somefile) but the file or directory it
signifies has already been deleted (i.e. /somefile does not exist) do not set
err = true; simply skip it.

Signed-off-by: Christian Brauner christian.brauner@mailbox.org
