### PR TITLE
add minimal tests (not yet operational)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,13 @@
+language: c
+compiler:
+        - gcc
+        - clang
+before_install:
+        - sudo apt-get update -qq
+        - sudo apt-get install -qq rsync docker apt-transport-https ca-certificates wget
+        - sudo apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 58118E89F3A912897C070ADBF76221572C52609D
+        - echo "deb https://apt.dockerproject.org/repo ubuntu-precise main" | sudo tee /etc/apt/sources.list.d/docker.list
+        - sudo apt-get update -qq
+        - sudo apt-cache policy docker-engine
+        - sudo apt-get install docker-engine
+script: make && sudo make install

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
-CC=gcc
 CFLAGS=-Wall -std=c99
+DESTDIR=/usr/local
+bindir=/bin
 
 new: clean all
 
@@ -15,3 +16,11 @@ melt.o: melt.c
 clean:
 	rm -rf *.o
 	rm -rf melt
+
+.PHONY: install
+install: melt
+	cp melt $(DESTDIR)$(bindir)/
+
+.PHONY: uninstall
+uninstall: melt
+	rm $(DESTDIR)$(bindir)/melt

--- a/tests/melt-test-1.sh
+++ b/tests/melt-test-1.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+
+# melt: Minimal tool to squash all layers of a docker image into a single layer 
+
+# Authors:
+# Christian Brauner <christian.brauner@mailbox.org>
+#
+
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+
+if [ $(id -u) -ne 0 ]; then
+	echo "ERROR: Must run as root."
+	exit 1
+fi
+
+tmpdir1=$(mktemp -d /tmp/melt_XXXX)
+tmpdir2=$(mktemp -d $tmpdir1/melt_XXXX)
+trap "rm -rf $tmpdir1" EXIT INT QUIT PIPE
+docker pull ubuntu:latest
+docker save ubuntu:latest > $tmpdir1/old.tar
+melt -i $tmpdir1/old.tar -o $tmpdir1/new.tar -t $tmpdir2
+cat $tmpdir1/new.tar | docker import - melted
+name=$(docker run --rm --hostname ubuntu melted:latest hostname)
+if [ "$name" != "ubuntu" ]; then
+	docker rmi melted:latest
+	rm -rf $tmpdir1
+	exit 1
+fi
+
+docker rmi melted:latest
+rm -rf $tmpdir1
+exit 0


### PR DESCRIPTION
Travis currently only provides Ubuntu-Precise which has a tar version that
misses the --acls flag which makes all tests fail.

Signed-off-by: Christian Brauner christian.brauner@mailbox.org
